### PR TITLE
added get-current-user-spots

### DIFF
--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const bcrypt = require('bcryptjs');
 
-const { setTokenCookie, requireAuth } = require('../../utils/auth');
+const { restoreUser, requireAuth } = require('../../utils/auth');
 const { Spot, Review, SpotImage } = require('../../db/models');
 const { check } = require('express-validator');
 const { handleValidationErrors } = require('../../utils/validation');
@@ -10,47 +10,68 @@ const { handleValidationErrors } = require('../../utils/validation');
 
 const router = express.Router();
 
+router.use(restoreUser)
+
+const fullSpot = async (spots) => {
+    let updatedSpots = []
+    for(let spot of spots){
+        const spotId = spot.id;
+        const reviews = await Review.findAll({
+            where: {spotId}
+        });
+        let reviewCount = reviews.length;
+        let starSum = reviews.reduce((sum, review) => sum + review.stars, 0);
+
+        let updatedSpot = spot.toJSON();
+
+        updatedSpot.avgRating = starSum / reviewCount;
+        
+
+
+        const previewImage = await SpotImage.findOne({
+            where: {
+                spotId,
+                isPreview: true
+            }
+        })
+        
+        updatedSpot.previewImage = previewImage.url;
+        updatedSpots.push(updatedSpot)
+    }
+    return updatedSpots
+}
 
 
 router.get('/', async (req, res, next) => {
     try {
-        
         const spots = await Spot.findAll()
 
         if(!spots){
             next(new Error('No spots currently exist'))
         }
-        let updatedSpots = []
-        for(let spot of spots){
-            const spotId = spot.id;
-            const reviews = await Review.findAll({
-                where: {spotId}
-            });
-            let reviewCount = reviews.length;
-            let starSum = reviews.reduce((sum, review) => sum + review.stars, 0);
-
-            let updatedSpot = spot.toJSON();
-
-            updatedSpot.avgRating = starSum / reviewCount;
-            
-
-
-            const previewImage = await SpotImage.findOne({
-                where: {
-                    spotId,
-                    isPreview: true
-                }
-            })
-            
-            updatedSpot.previewImage = previewImage.url;
-            updatedSpots.push(updatedSpot)
-        }
-       
+        
+        let updatedSpots = await fullSpot(spots)
+           
         res.json(updatedSpots)
-
     } catch (error) {
         next(error)
     }
+})
+
+router.get('/current', requireAuth, async (req, res, next) => {
+    const userId = req.user.id;
+    const spots = await Spot.findAll({
+        where: {
+            ownerId: userId
+        }
+    })
+
+    const updatedSpots = await fullSpot(spots)
+
+    res.json({
+        Spots: updatedSpots
+    })
+
 })
 
 

--- a/backend/utils/auth.js
+++ b/backend/utils/auth.js
@@ -47,7 +47,7 @@ const restoreUser = (req, res, next) => {
         const { id } = jwtPayload.data;
         req.user = await User.findByPk(id, {
           attributes: {
-            include: ['email', 'createdAt', 'updatedAt']
+            include: ['id', 'email', 'createdAt', 'updatedAt']
           }
         });
       } catch (e) {


### PR DESCRIPTION
### Added Get Current User's Spots route

- [x] An authenticated user is required for a successful response
- [x] Successful response includes only spots created by the current user
- [x] Spot data returned includes the `id`, `ownerId`, `address`, `city`,
  `state`, `country`, `lat`, `lng`, `name`, `description`, `price`, `createdAt`,
  `updatedAt`, `previewImage`, and `avgRating`